### PR TITLE
fix: add undici package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "autocannon": "^7.6.0",
     "tap": "^15.1.6"
   },
-  "name": "new-promises-workshop-exercises"
+  "name": "new-promises-workshop-exercises",
+  "devDependencies": {
+    "undici": "^4.12.2"
+  }
 }


### PR DESCRIPTION
In the exercise 3, `test.mjs` requires the `undici` but it wasn't in the package.json